### PR TITLE
support 0.percent_of_the_time

### DIFF
--- a/lib/sometimes.rb
+++ b/lib/sometimes.rb
@@ -19,7 +19,8 @@ require "sometimes/version"
 # 40.percent_of_the_time do
 class Fixnum
   def percent_of_the_time(&block)
-    raise(ArgumentError, 'Fixnum should be between 1 and 100 to be used with the times method') unless self > 0 && self <= 100
+    return if self == 0
+    raise(ArgumentError, 'Fixnum should be between 0 and 100 to be used with the percent_of_the_time method') unless self > 0 && self <= 100
     yield if (Kernel.rand(99)+1) <= self
   end
 end

--- a/test/test_sometimes.rb
+++ b/test/test_sometimes.rb
@@ -61,6 +61,16 @@ class SometimesTest < Test::Unit::TestCase
     assert i < 1100
   end
 
+  def test_0
+    bool = true
+    100000.times do
+      0.percent_of_the_time do
+        bool = false
+      end
+    end
+    assert_equal true, bool
+  end
+
   def test_never
     bool = true
     never do


### PR DESCRIPTION
I was using the `percent_of_the_time` helper to decide how often to do something, but the range could go down to zero. Rather than have to modify my method to skip the block if my calculated percentage were zero, it'd be handy if this helper knew that being called on a `0` meant a no-op.
